### PR TITLE
Exposing time-base properties in codecs and key-frame check for packets.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -102,6 +102,12 @@ impl Decoder {
         })
     }
 
+    /// Get decoder time base.
+    #[inline]
+    pub fn time_base(&self) -> AvRational {
+        self.decoder.time_base()
+    }
+
     /// Decode frames through iterator interface. This is similar to `decode` but it returns frames
     /// through an infinite iterator.
     ///
@@ -221,6 +227,13 @@ pub struct DecoderSplit {
 }
 
 impl DecoderSplit {
+
+    /// Get decoder time base.
+    #[inline]
+    pub fn time_base(&self) -> AvRational {
+        self.decoder_time_base
+    }
+
     /// Decode a [`Packet`].
     ///
     /// Feeds the packet to the decoder and returns a frame if there is one available. The caller

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -227,7 +227,6 @@ pub struct DecoderSplit {
 }
 
 impl DecoderSplit {
-
     /// Get decoder time base.
     #[inline]
     pub fn time_base(&self) -> AvRational {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -126,6 +126,12 @@ impl Encoder {
         self
     }
 
+    /// Get encoder time base.
+    #[inline]
+    pub fn time_base(&self) -> AvRational {
+        self.encoder_time_base
+    }
+
     /// Encode a single `ndarray` frame.
     ///
     /// # Arguments

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -31,6 +31,12 @@ impl Packet {
         Time::new(Some(self.inner.duration()), self.time_base)
     }
 
+    // Check whether packet is key.
+    #[inline]
+    pub fn is_key(&self) -> bool {
+        self.inner.is_key()
+    }
+
     /// Set packet PTS (presentation timestamp).
     #[inline]
     pub fn set_pts(&mut self, timestamp: &Time) {


### PR DESCRIPTION
Added `is_key` method to `Packet` to expose key-frame flag of the packet to allow for key-frame search using `Reader`.
Exposed time-base propeties of `Decoder`, `DecoderSplit` and `Encoder` to support explicit sourdce and destination PTS and DTS computation.