### PR TITLE
Added a public function to set custom pixel format and encoder options

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -21,7 +21,7 @@ use crate::{
     frame::FRAME_PIXEL_FORMAT,
     io::{private::Write, Writer},
     options::Options,
-    Error, Locator, RawFrame, PixelFormat
+    Error, Locator, PixelFormat, RawFrame,
 };
 
 #[cfg(feature = "ndarray")]
@@ -408,8 +408,14 @@ impl<'o> Settings<'o> {
     ///
     /// # Return value
     ///
-    /// A `Settings` instance with the specified configuration.
-    pub fn for_h264_custom(width: usize, height: usize, pixel_format: PixelFormat, options: Options<'o>) -> Settings<'o> {
+    /// A `Settings` instance with the specified configuration.+
+    pub fn for_h264_custom(
+        width: usize,
+        height: usize,
+        pixel_format:
+        PixelFormat,
+        options: Options<'o>,
+    ) -> Settings<'o> {
         Self {
             width: width as u32,
             height: height as u32,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -412,8 +412,7 @@ impl<'o> Settings<'o> {
     pub fn for_h264_custom(
         width: usize,
         height: usize,
-        pixel_format:
-        PixelFormat,
+        pixel_format: PixelFormat,
         options: Options<'o>,
     ) -> Settings<'o> {
         Self {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -21,7 +21,7 @@ use crate::{
     frame::FRAME_PIXEL_FORMAT,
     io::{private::Write, Writer},
     options::Options,
-    Error, Locator, RawFrame,
+    Error, Locator, RawFrame, PixelFormat
 };
 
 #[cfg(feature = "ndarray")]
@@ -409,7 +409,7 @@ impl<'o> Settings<'o> {
     /// # Return value
     ///
     /// A `Settings` instance with the specified configuration.
-    pub fn for_h264_custom(width: usize, height: usize, pixel_format: AvPixel, options: Options<'o>) -> Settings<'o> {
+    pub fn for_h264_custom(width: usize, height: usize, pixel_format: PixelFormat, options: Options<'o>) -> Settings<'o> {
         Self {
             width: width as u32,
             height: height as u32,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -395,6 +395,29 @@ impl<'o> Settings<'o> {
         }
     }
 
+    /// Create encoder settings for an H264 stream with a custom pixel format and options.
+    /// This allows for greater flexibility in encoding settings, enabling specific requirements
+    /// or optimizations to be set depending on the use case.
+    ///
+    /// # Arguments
+    ///
+    /// * `width` - The width of the video stream.
+    /// * `height` - The height of the video stream.
+    /// * `pixel_format` - The desired pixel format for the video stream.
+    /// * `options` - Custom H264 encoding options.
+    ///
+    /// # Return value
+    ///
+    /// A `Settings` instance with the specified configuration.
+    pub fn for_h264_custom(width: usize, height: usize, pixel_format: AvPixel, options: Options<'o>) -> Settings<'o> {
+        Self {
+            width: width as u32,
+            height: height as u32,
+            pixel_format,
+            options,
+        }
+    }
+
     /// Apply the settings to an encoder.
     ///
     /// # Arguments

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,7 +1,10 @@
 extern crate ffmpeg_next as ffmpeg;
 
-pub use ffmpeg::util::format::Pixel as AvPixel;
+use ffmpeg::util::format::Pixel as AvPixel;
 use ffmpeg::util::frame::Video as AvFrame;
+
+/// Re-export internal `AvPixel` as `PixelFormat` for callers.
+pub type PixelFormat = AvPixel;
 
 /// Re-export internal `AvFrame` for caller to use.
 pub type RawFrame = AvFrame;

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,6 +1,6 @@
 extern crate ffmpeg_next as ffmpeg;
 
-use ffmpeg::util::format::Pixel as AvPixel;
+pub use ffmpeg::util::format::Pixel as AvPixel;
 use ffmpeg::util::frame::Video as AvFrame;
 
 /// Re-export internal `AvFrame` for caller to use.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use decode::{Decoder, DecoderSplit};
 pub use encode::{Encoder, Settings as EncoderSettings};
 pub use error::Error;
 pub use extradata::{Pps, Sps};
-pub use frame::AvPixel;
+pub use frame::PixelFormat;
 pub use frame::RawFrame;
 pub use init::init;
 pub use io::{Buf, Reader, Write, Writer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use decode::{Decoder, DecoderSplit};
 pub use encode::{Encoder, Settings as EncoderSettings};
 pub use error::Error;
 pub use extradata::{Pps, Sps};
+pub use frame::AvPixel;
 pub use frame::RawFrame;
 pub use init::init;
 pub use io::{Buf, Reader, Write, Writer};


### PR DESCRIPTION
### Added the 'for_h264_custom' function:

- This function is tailored for specific H264 stream encoding requirements.
- It accepts width, height, desired pixel format, and custom H264 encoding options as arguments.
- It returns a Settings instance tailored with the given configuration.

By providing this custom encoder settings function, we can cater to specific encoding requirements or optimizations depending on the use case, offering more flexibility for users.