### PR TITLE
Use `ffmpeg-the-third` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,6 @@ readme = "README.md"
 
 [dependencies]
 tracing = "0.1"
-ffmpeg-next = { version = "6.0", features = [
-    "format",
-    "codec",
-    "software-resampling",
-    "software-scaling",
-] }
 url = "2"
 ndarray = { version = "0.15", optional = true }
+ffmpeg-the-third = "1.2.2"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ media library without depending on ffmpeg.
 
 First, install the `ffmpeg` libraries. The `ffmpeg-next` project has
 [excellent instructions](https://github.com/zmwangx/rust-ffmpeg/wiki/Notes-on-building#dependencies)
-on this (`video-rs` depends on the `ffmpeg-next` crate).
+on this (`video-rs` depends on the `ffmpeg-the-third` crate).
 
 Then, add the following to your dependencies in `Cargo.toml`:
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::codec::decoder::Video as AvDecoder;
 use ffmpeg::codec::Context as AvContext;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::codec::codec::Codec as AvCodec;
 use ffmpeg::codec::encoder::video::Encoder as AvEncoder;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::Error as FfmpegError;
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 #[cfg(feature = "ndarray")]
 use ndarray::Array3;
@@ -15,7 +15,7 @@ use ffmpeg::util::format::Pixel;
 
 use ffmpeg::ffi::*;
 
-/// This function is similar to the existing bindings in ffmpeg-next like `output` and `output_as`,
+/// This function is similar to the existing bindings in ffmpeg-the-third like `output` and `output_as`,
 /// but does not assume that it is opening a file-like context. Instead, it opens a raw output,
 /// without a file attached.
 ///

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::util::format::Pixel as AvPixel;
 use ffmpeg::util::frame::Video as AvFrame;

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use crate::ffi::init_logging;
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use std::path::{Path, PathBuf};
 
@@ -401,7 +401,7 @@ pub enum Locator {
 }
 
 impl Locator {
-    /// Resolves the locator into a `PathBuf` for usage with `ffmpeg-next`.
+    /// Resolves the locator into a `PathBuf` for usage with `ffmpeg-the-third`.
     fn resolve(&self) -> &Path {
         match self {
             Locator::Path(path) => path.as_path(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,4 +35,4 @@ pub use time::{Aligned, Time};
 pub use frame::Frame;
 
 /// Re-export inner `ffmpeg` library.
-pub use ffmpeg_next as ffmpeg;
+pub use ffmpeg_the_third as ffmpeg;

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use std::collections::HashMap;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use std::collections::HashMap;
 
@@ -87,7 +87,7 @@ impl Options<'_> {
         Self(opts)
     }
 
-    /// Convert back to ffmpeg native dictionary, which can be used with `ffmpeg_next` functions.
+    /// Convert back to ffmpeg native dictionary, which can be used with `ffmpeg_the_third` functions.
     pub(super) fn to_dict(&self) -> AvDictionary {
         self.0.clone()
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::codec::packet::Packet as AvPacket;
 use ffmpeg::Rational as AvRational;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use ffmpeg::codec::Parameters as AvCodecParameters;
 use ffmpeg::{Error as AvError, Rational as AvRational};

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,4 +1,4 @@
-extern crate ffmpeg_next as ffmpeg;
+extern crate ffmpeg_the_third as ffmpeg;
 
 use std::time::Duration;
 


### PR DESCRIPTION
[ffmpeg-the-third](https://github.com/shssoichiro/ffmpeg-the-third) is a fork of the abandoned [ffmpeg-next](https://github.com/zmwangx/rust-ffmpeg) crate, which is a fork of the abandoned `ffmpeg` crate, adding features like FFmpeg 5.x and FFmpeg 6.x support.