### PR TITLE
Added flag to build docs for all features on `docs.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,15 @@ repository = "https://github.com/oddity-ai/video-rs"
 readme = "README.md"
 
 [dependencies]
-tracing = "0.1"
 ffmpeg-next = { version = "7.0", features = [
     "format",
     "codec",
     "software-resampling",
     "software-scaling",
 ] }
-url = "2"
 ndarray = { version = "0.15", optional = true }
+tracing = "0.1"
+url = "2"
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
TLDR; anything behind a feature flag in this crate is undocumented on `docs.rs`.

Specifically, a first time user will find that the encoder example in the README uses `decode_iter()` which is undocumented on `docs.rs`. The reason is that this is behind the `ndarray` flag which is *off* by default.

* Added `[package.metadata.docs.rs]` entry to `Cargo.toml` to fix this.
* Ran `cargo sort` to sort deps in `Cargo.toml` alphabetically.