### PR TITLE
Add feature option to disable vulkan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ ffmpeg-next = { version = "7.0", features = [
 ] }
 url = "2"
 ndarray = { version = "0.15", optional = true }
+
+[features]
+no_vulkan = []

--- a/src/hwaccel.rs
+++ b/src/hwaccel.rs
@@ -59,6 +59,7 @@ pub enum HardwareAccelerationDeviceType {
     /// MediaCodec
     MeiaCodec,
     /// Vulkan
+    #[cfg(not(feature = "no_vulkan"))]
     Vulkan,
     /// Direct3D 12 Video Acceleration
     D3D12Va,
@@ -91,6 +92,7 @@ impl HardwareAccelerationDeviceType {
             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_DRM => Some(Self::Drm),
             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_OPENCL => Some(Self::OpenCl),
             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_MEDIACODEC => Some(Self::MeiaCodec),
+            #[cfg(not(feature = "no_vulkan"))]
             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VULKAN => Some(Self::Vulkan),
             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_NONE => None,
             // FIXME: Find a way to handle the new variants in ffmpeg 7 without breaking backwards
@@ -134,6 +136,7 @@ impl From<HardwareAccelerationDeviceType> for ffmpeg::ffi::AVHWDeviceType {
             HardwareAccelerationDeviceType::MeiaCodec => {
                 ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_MEDIACODEC
             }
+            #[cfg(not(feature = "no_vulkan"))]
             HardwareAccelerationDeviceType::Vulkan => {
                 ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VULKAN
             }


### PR DESCRIPTION
When trying to compile `video-rs` on a machine running on Ubuntu 20.04.6 LTS, with the following ffmpeg version:
```
ffmpeg version 4.2.7-0ubuntu0.1 Copyright (c) 2000-2022 the FFmpeg developers
built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)
configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
libavutil      56. 31.100 / 56. 31.100
libavcodec     58. 54.100 / 58. 54.100
libavformat    58. 29.100 / 58. 29.100
libavdevice    58.  8.100 / 58.  8.100
libavfilter     7. 57.100 /  7. 57.100
libavresample   4.  0.  0 /  4.  0.  0
libswscale      5.  5.100 /  5.  5.100
libswresample   3.  5.100 /  3.  5.100
libpostproc    55.  5.100 / 55.  5.100
```

I get the following error:
```sh
error[E0599]: no variant or associated item named `AV_HWDEVICE_TYPE_VULKAN` found for enum `AVHWDeviceType` in the current scope                                                                                                               
  --> src/hwaccel.rs:96:42                                                                                                                                                                                                                     
   |                                                                                                                                                                                                                                           
96 |             ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VULKAN => Some(Self::Vulkan),                                                                                                                                                   
   |                                          ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                          
   |                                          |                                                                                                                                                                                                
   |                                          variant or associated item not found in `AVHWDeviceType`                                                                                                                                         
   |                                          help: there is a variant with a similar name: `AV_HWDEVICE_TYPE_VDPAU`                                                                                                                           
                                                                                                                                                                                                                                               
error[E0599]: no variant or associated item named `AV_HWDEVICE_TYPE_VULKAN` found for enum `AVHWDeviceType` in the current scope                                                                                                               
   --> src/hwaccel.rs:141:46                                                                                                                                                                                                                   
    |                                                                                                                                                                                                                                          
141 |                 ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VULKAN                                                                                                                                                                     
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                     
    |                                              |                                                                                                                                                                                           
    |                                              variant or associated item not found in `AVHWDeviceType`                                                                                                                                    
    |                                              help: there is a variant with a similar name: `AV_HWDEVICE_TYPE_VDPAU` 
```

So I came up with this simple solution of adding a feature to disable Vulkan. Dont know if there is a better way to do this though.
