### PR TITLE
Add frame-specific seeking

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -224,7 +224,19 @@ impl Decoder {
     /// See [`Reader::seek`](crate::io::Reader::seek) for more information.
     #[inline]
     pub fn seek(&mut self, timestamp_milliseconds: i64) -> Result<()> {
-        self.reader.seek(timestamp_milliseconds)
+        self.reader
+            .seek(timestamp_milliseconds)
+            .inspect(|_| self.decoder.decoder.flush())
+    }
+
+    /// Seek to specific frame in reader.
+    ///
+    /// See [`Reader::seek_to_frame`](crate::io::Reader::seek_to_frame) for more information.
+    #[inline]
+    pub fn seek_to_frame(&mut self, frame_number: i64) -> Result<()> {
+        self.reader
+            .seek_to_frame(frame_number)
+            .inspect(|_| self.decoder.decoder.flush())
     }
 
     /// Seek to start of reader.
@@ -232,7 +244,9 @@ impl Decoder {
     /// See [`Reader::seek_to_start`](crate::io::Reader::seek_to_start) for more information.
     #[inline]
     pub fn seek_to_start(&mut self) -> Result<()> {
-        self.reader.seek_to_start()
+        self.reader
+            .seek_to_start()
+            .inspect(|_| self.decoder.decoder.flush())
     }
 
     /// Split the decoder into a decoder (of type [`DecoderSplit`]) and a [`Reader`].

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,6 +5,7 @@ use ffmpeg::ffi::AV_TIME_BASE_Q;
 use ffmpeg::format::context::{Input as AvInput, Output as AvOutput};
 use ffmpeg::media::Type as AvMediaType;
 use ffmpeg::Error as AvError;
+use ffmpeg_next::ffi::av_seek_frame;
 
 use crate::error::Error;
 use crate::ffi;
@@ -155,6 +156,20 @@ impl Reader {
         self.input
             .seek(timestamp, range)
             .map_err(Error::BackendError)
+    }
+
+    /// Seek to a specific frame in the video stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `frame_number` - The frame number to seek to.
+    pub fn seek_to_frame(&mut self, frame_number: i64) -> Result<()> {
+        unsafe {
+            match av_seek_frame(self.input.as_mut_ptr(), -1, frame_number, 0) {
+                0 => Ok(()),
+                e => Err(Error::BackendError(AvError::from(e))),
+            }
+        }
     }
 
     /// Seek to start of reader. This function performs best effort seeking to the start of the


### PR DESCRIPTION
I added a new `seek_to_frame` method for seeking to specific frames in the video stream. The decoder's buffer is now flushed after to prevent potential artifacts or inconsistencies that could occur when processing frames immediately after a seek operation.