### PR TITLE
Allow creating packets / streaminfo from outside the crate

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -65,7 +65,7 @@ impl Packet {
     ///
     /// * `inner` - Inner `AvPacket`.
     /// * `time_base` - Source time base.
-    pub(crate) fn new(inner: AvPacket, time_base: AvRational) -> Self {
+    pub fn new(inner: AvPacket, time_base: AvRational) -> Self {
         Self { inner, time_base }
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -30,10 +30,14 @@ impl StreamInfo {
             .stream(stream_index)
             .ok_or(AvError::StreamNotFound)?;
 
+        Self::from_params(stream.parameters(), stream.time_base(), stream_index)
+    }
+
+    pub fn from_params(copar: AvCodecParameters, timebase: AvRational, stream_index: usize) -> Result<Self> {
         Ok(Self {
             index: stream_index,
-            codec_parameters: stream.parameters(),
-            time_base: stream.time_base(),
+            codec_parameters: copar,
+            time_base: timebase,
         })
     }
 


### PR DESCRIPTION
In my application I need to use oddity-rtsp-server as a basis for streaming from a raspberry pi.  The H264 NALs from the pi can easily be muxed with oddity-rtsp-server provided the packet constructor is "pub" (proposed change), not "pub(crate)" (current upstream).  

Likewise the AvCodecParameters/AvRational are being provided by an external library - so I needed to construct a video-rs streaminfo from these.  Adding the "from_info" constructor facilitates this.  