### PR TITLE
fix: hwdevice_list_available_device_types  handling of unimplemented ffmpeg HardwareAccelerationDe…

### DIFF
--- a/src/ffi_hwaccel.rs
+++ b/src/ffi_hwaccel.rs
@@ -45,7 +45,9 @@ pub fn hwdevice_list_available_device_types() -> Vec<HardwareAccelerationDeviceT
         ffmpeg::ffi::av_hwdevice_iterate_types(ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_NONE)
     };
     while hwdevice_type != ffmpeg::ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_NONE {
-        hwdevice_types.push(HardwareAccelerationDeviceType::from(hwdevice_type).unwrap());
+        if let Some(device_type) = HardwareAccelerationDeviceType::from(hwdevice_type) {
+            hwdevice_types.push(device_type);
+        }
         hwdevice_type = unsafe { ffmpeg::ffi::av_hwdevice_iterate_types(hwdevice_type) };
     }
     hwdevice_types

--- a/src/hwaccel.rs
+++ b/src/hwaccel.rs
@@ -93,7 +93,7 @@ impl HardwareAccelerationDeviceType {
             // FIXME: Find a way to handle the new variants in ffmpeg 7 without breaking backwards
             // compatibility...
             #[allow(unreachable_patterns)]
-            _ => unimplemented!(),
+            _ => None
         }
     }
 }


### PR DESCRIPTION
FIXES #64 

Panicking `unimplemented!()` in `HardwareAccelerationDeviceType::from` causes `HardwareAccelerationDeviceType::list_available();` to panic due to the path raised in #64.

https://github.com/rgon/video-rs/blob/18699e5d1d8a69d04df9413bd404f5e7b77f3637/src/hwaccel.rs#L93-L96

This PR switches the panic to idiomatic `Option<>` handling (since the `::from(...)` method already returns an `Option` -> thus this is no breaking change. 

Then, it checks the option in `ffi_hwaccel.rs` to properly take into account unimplemented devices.

Result of the reproduction in the issue:
```
     Running `target/debug/examples/ffmpeg_bug_repro`
Available hardware acceleration types: [Vdpau, Cuda, VaApi, Qsv, Drm, OpenCl]
Test ok
```